### PR TITLE
add ability to retrieve Application's hostServices

### DIFF
--- a/src/main/java/de/felixroske/jfxsupport/AbstractJavaFxApplicationSupport.java
+++ b/src/main/java/de/felixroske/jfxsupport/AbstractJavaFxApplicationSupport.java
@@ -8,6 +8,7 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.context.ConfigurableApplicationContext;
 
 import javafx.application.Application;
+import javafx.application.HostServices;
 import javafx.application.Platform;
 import javafx.beans.property.BooleanProperty;
 import javafx.beans.property.SimpleBooleanProperty;
@@ -43,6 +44,10 @@ public abstract class AbstractJavaFxApplicationSupport extends Application {
 	public static Scene getScene() {
 		return GUIState.getScene();
 	}
+	
+	public static HostServices getAppHostServices() {
+            return GUIState.getHostServices();
+        }
 
 	/*
 	 * (non-Javadoc)
@@ -77,6 +82,7 @@ public abstract class AbstractJavaFxApplicationSupport extends Application {
 	@Override
 	public void start(final Stage stage) throws Exception {
 		GUIState.setStage(stage);
+		GUIState.setHostServices(this.getHostServices());
 		final Stage splashStage = new Stage(StageStyle.UNDECORATED);
 
 		if (AbstractJavaFxApplicationSupport.splashScreen.visible()) {
@@ -234,5 +240,5 @@ public abstract class AbstractJavaFxApplicationSupport extends Application {
 		}
 		Application.launch(appClass, args);
 	}
-
+	
 }

--- a/src/main/java/de/felixroske/jfxsupport/GUIState.java
+++ b/src/main/java/de/felixroske/jfxsupport/GUIState.java
@@ -1,5 +1,6 @@
 package de.felixroske.jfxsupport;
 
+import javafx.application.HostServices;
 import javafx.scene.Scene;
 import javafx.stage.Stage;
 
@@ -18,6 +19,8 @@ public enum GUIState {
 	private static Stage stage;
 
 	private static String title;
+	
+	private static HostServices hostServices;
 
 	public static String getTitle() {
 		return title;
@@ -42,5 +45,15 @@ public enum GUIState {
 	public static void setTitle(final String title) {
 		GUIState.title = title;
 	}
+
+        public static HostServices getHostServices() {
+            return hostServices;
+        }
+
+        public static void setHostServices(HostServices hostServices) {
+            GUIState.hostServices = hostServices;
+        }
+	
+	
 
 }


### PR DESCRIPTION
Using the library I found myself unable to access the Application HostServices (used e.g. to call HostServices#showDocument that will open a link in user browser instead of a java-fx widget).

This PR tries to answer this problem. 