### PR TITLE
Revised bundle name detection in AbstractFxmlView.getBundleName()

### DIFF
--- a/src/main/java/de/felixroske/jfxsupport/AbstractFxmlView.java
+++ b/src/main/java/de/felixroske/jfxsupport/AbstractFxmlView.java
@@ -354,15 +354,15 @@ public abstract class AbstractFxmlView implements ApplicationContextAware {
 	 * @return the bundle name
 	 */
 	private String getBundleName() {
-		if (!StringUtils.isEmpty(annotation)) {
-			final String lbundle = annotation.bundle();
-			LOGGER.debug("Annotated bundle: {}", lbundle);
-			return lbundle;
-		} else {
+		if (StringUtils.isEmpty(annotation.bundle())) {
 			final String lbundle = getClass().getPackage().getName() + "." + getConventionalName();
 			LOGGER.debug("Bundle: {} based on conventional name.", lbundle);
 			return lbundle;
 		}
+
+		final String lbundle = annotation.bundle();
+		LOGGER.debug("Annotated bundle: {}", lbundle);
+		return lbundle;
 	}
 
 	/**

--- a/src/test/java/jfxtest/annotated/AnnotatedUnconventionalNameTest.java
+++ b/src/test/java/jfxtest/annotated/AnnotatedUnconventionalNameTest.java
@@ -15,7 +15,7 @@ import de.roskenet.jfxsupport.test.GuiTest;
 import javafx.scene.control.Button;
 @RunWith(SpringRunner.class)
 @SpringBootTest
-public class AnnotatedUnconventionalName extends GuiTest {
+public class AnnotatedUnconventionalNameTest extends GuiTest {
 	
 	@Autowired
 	private Annotated buttonsView;
@@ -25,12 +25,13 @@ public class AnnotatedUnconventionalName extends GuiTest {
         init(buttonsView);
     }
 	
-	@Test
-	/* 
+	/*
 	 * Asserts that we can find a view if the class name doesn't end with 'view'
+	 * see https://github.com/roskenet/springboot-javafx-support/issues/38
 	 */
+	@Test
 	public void showsI18nText() throws Exception {
 	   Button theButton = (Button) find("#theButton");
-	   assertThat(theButton.getText(), is("The Button Text"));
+	   assertThat(theButton.getText(), is("The default Button Text"));
 	}
 }

--- a/src/test/resources/jfxtest/annotated/annotated.fxml
+++ b/src/test/resources/jfxtest/annotated/annotated.fxml
@@ -5,6 +5,6 @@
 
 <Pane maxHeight="-Infinity" maxWidth="-Infinity" minHeight="-Infinity" minWidth="-Infinity" prefHeight="400.0" prefWidth="600.0" xmlns="http://javafx.com/javafx/8.0.112" xmlns:fx="http://javafx.com/fxml/1">
    <children>
-      <Button fx:id="theButton" layoutX="262.0" layoutY="187.0" mnemonicParsing="false" text="The Button Text" />
+      <Button fx:id="theButton" layoutX="262.0" layoutY="187.0" mnemonicParsing="false" text="%thebuttontext" />
    </children>
 </Pane>

--- a/src/test/resources/jfxtest/annotated/annotated.properties
+++ b/src/test/resources/jfxtest/annotated/annotated.properties
@@ -1,0 +1,1 @@
+thebuttontext=The default Button Text


### PR DESCRIPTION
Previously getBundleName() always returned the value from
FXMLView#bundle attribute, due to testing the annotation instead of
the bundle-name for being empty.

We now correctly test the configured bundle-name. If the bundle name is
null we or empty we derive the bundle name from the classname.
Otherwise we use the value as is.

Fixes #38
Can be backported to 1.4.x