### PR TITLE
Feat/reuse icon for splashscreen

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -80,6 +80,18 @@
       <version>4.12</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.testfx</groupId>
+      <artifactId>testfx-core</artifactId>
+      <version>4.0.8-alpha</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.testfx</groupId>
+      <artifactId>testfx-junit</artifactId>
+      <version>4.0.8-alpha</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <distributionManagement>

--- a/src/main/java/de/felixroske/jfxsupport/AbstractJavaFxApplicationSupport.java
+++ b/src/main/java/de/felixroske/jfxsupport/AbstractJavaFxApplicationSupport.java
@@ -36,11 +36,10 @@ public abstract class AbstractJavaFxApplicationSupport extends Application {
 
     private static String[] savedArgs = new String[0];
 
-    private static Class<? extends AbstractFxmlView> savedInitialView;
-
+    static Class<? extends AbstractFxmlView> savedInitialView;
+    static SplashScreen splashScreen;
     private static ConfigurableApplicationContext applicationContext;
 
-    private static SplashScreen splashScreen;
 
     private static List<Image> icons = new ArrayList<>();
     private final List<Image> defaultIcons = new ArrayList<>();

--- a/src/main/java/de/felixroske/jfxsupport/AbstractJavaFxApplicationSupport.java
+++ b/src/main/java/de/felixroske/jfxsupport/AbstractJavaFxApplicationSupport.java
@@ -9,6 +9,7 @@ import javafx.scene.Scene;
 import javafx.scene.control.Alert;
 import javafx.scene.control.Alert.AlertType;
 import javafx.scene.image.Image;
+import javafx.scene.paint.Color;
 import javafx.stage.Modality;
 import javafx.stage.Stage;
 import javafx.stage.StageStyle;
@@ -144,12 +145,13 @@ public abstract class AbstractJavaFxApplicationSupport extends Application {
 
         GUIState.setStage(stage);
         GUIState.setHostServices(this.getHostServices());
-        final Stage splashStage = new Stage(StageStyle.UNDECORATED);
+        final Stage splashStage = new Stage(StageStyle.TRANSPARENT);
 
         if (AbstractJavaFxApplicationSupport.splashScreen.visible()) {
-            final Scene splashScene = new Scene(splashScreen.getParent());
+            final Scene splashScene = new Scene(splashScreen.getParent(), Color.TRANSPARENT);
             splashStage.setScene(splashScene);
             splashStage.getIcons().addAll(defaultIcons);
+            splashStage.initStyle(StageStyle.TRANSPARENT);
             beforeShowingSplash(splashStage);
             splashStage.show();
         }

--- a/src/test/java/de/felixroske/jfxsupport/AbstractJavaFxApplicationSupportTest.java
+++ b/src/test/java/de/felixroske/jfxsupport/AbstractJavaFxApplicationSupportTest.java
@@ -1,0 +1,56 @@
+package de.felixroske.jfxsupport;
+
+import javafx.scene.image.Image;
+import jfxtest.annotated.AnnotatedView;
+import org.hamcrest.CoreMatchers;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.testfx.api.FxToolkit;
+
+import java.util.ArrayList;
+import java.util.Collection;
+
+import static org.junit.Assert.assertThat;
+
+/**
+ * Created on 11/3/2017 for Onyx.
+ */
+//@RunWith(SpringRunner.class)
+//@SpringBootTest
+public class AbstractJavaFxApplicationSupportTest { //extends GuiTest {
+
+    private AbstractJavaFxApplicationSupport app;
+
+    public class TestApp extends AbstractJavaFxApplicationSupport {
+
+    }
+
+    @BeforeClass
+    public static void beforeClass() {
+        System.setProperty("testfx.headless", "true");
+    }
+
+    @AfterClass
+    public static void afterClass() {
+        System.setProperty("testfx.headless", "false");
+    }
+
+    @Before
+    public void setup() throws Exception {
+        FxToolkit.registerPrimaryStage();
+        app = new TestApp();
+        app.savedInitialView = AnnotatedView.class;
+        app.splashScreen = new SplashScreen();
+        FxToolkit.setupApplication(() -> app);
+    }
+
+    @Test
+    public void loadDefaultIcons() throws Exception {
+        final Collection<Image> images = new ArrayList<>();
+        images.addAll(app.loadDefaultIcons());
+        assertThat(images.size(), CoreMatchers.is(5));
+    }
+
+}


### PR DESCRIPTION
Main idea is 
* to reuse stage icons between splash and main stage when possible
* tune splash to handle image with background transparency

If second commit is (transparency) is KO for u, I can remove.
Chris.