### PR TITLE
Fix: #54 Specify a resource bundle encoding in @FXMLView-annotation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 .project
 /.settings/
 .springBeans
+/.idea/

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 .project
 /.settings/
 .springBeans
+/.idea/
+*.iml

--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,3 @@
 .project
 /.settings/
 .springBeans
-/.idea/

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>de.roskenet</groupId>
   <artifactId>springboot-javafx-support</artifactId>
-  <version>2.1.5</version>
+  <version>2.1.6-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>springboot-javafx-support</name>
@@ -17,7 +17,7 @@
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
     <spring-framework.version>5.0.0.RELEASE</spring-framework.version>
-    <spring-boot.version>2.0.0.M6</spring-boot.version>
+    <spring-boot.version>2.0.0.RELEASE</spring-boot.version>
     <spring-boot-javafx-test.version>1.2.0</spring-boot-javafx-test.version>
     <slf4j.version>1.7.25</slf4j.version>
   </properties>

--- a/src/main/java/de/felixroske/jfxsupport/AbstractFxmlView.java
+++ b/src/main/java/de/felixroske/jfxsupport/AbstractFxmlView.java
@@ -1,23 +1,5 @@
 package de.felixroske.jfxsupport;
 
-import static java.util.ResourceBundle.getBundle;
-
-import java.io.IOException;
-import java.net.URL;
-import java.util.List;
-import java.util.MissingResourceException;
-import java.util.Optional;
-import java.util.ResourceBundle;
-import java.util.concurrent.CompletableFuture;
-import java.util.function.Consumer;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.beans.BeansException;
-import org.springframework.context.ApplicationContext;
-import org.springframework.context.ApplicationContextAware;
-import org.springframework.util.StringUtils;
-
 import javafx.application.Platform;
 import javafx.beans.property.ObjectProperty;
 import javafx.beans.property.SimpleObjectProperty;
@@ -28,6 +10,25 @@ import javafx.scene.Node;
 import javafx.scene.Parent;
 import javafx.scene.layout.AnchorPane;
 import javafx.stage.StageStyle;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.BeansException;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.ApplicationContextAware;
+import org.springframework.util.StringUtils;
+
+import java.io.IOException;
+import java.net.URL;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.MissingResourceException;
+import java.util.Optional;
+import java.util.ResourceBundle;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Consumer;
+
+import static java.util.ResourceBundle.getBundle;
 
 /**
  * Base class for fxml-based view classes.
@@ -403,17 +404,24 @@ public abstract class AbstractFxmlView implements ApplicationContextAware {
 	 * @return the resource bundle
 	 */
 	private Optional<ResourceBundle> getResourceBundle(final String name) {
-	    ResourceBundle bundle;
-
 		try {
 			LOGGER.debug("Resource bundle: " + name);
-			bundle = getBundle(name);
+			return Optional.of(getBundle(name,
+				new ResourceBundleControl(getResourceBundleCharset())));
 		} catch (final MissingResourceException ex) {
 			LOGGER.debug("No resource bundle could be determined: " + ex.getMessage());
-			bundle = null;
+			return Optional.empty();
 		}
-		
-		return Optional.ofNullable(bundle);
+	}
+
+	/**
+	 * Returns the charset to use when reading resource bundles as specified in
+	 * the annotation.
+	 *
+	 * @return  the charset
+	 */
+	private Charset getResourceBundleCharset() {
+		return Charset.forName(annotation.encoding());
 	}
 
 	/**

--- a/src/main/java/de/felixroske/jfxsupport/FXMLView.java
+++ b/src/main/java/de/felixroske/jfxsupport/FXMLView.java
@@ -1,11 +1,9 @@
 package de.felixroske.jfxsupport;
 
-import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
-
 import org.springframework.stereotype.Component;
 
-import javafx.stage.StageStyle;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
 
 /**
  * The annotation {@link FXMLView} indicates a class to be used in the context
@@ -38,6 +36,14 @@ public @interface FXMLView {
 	 * @return the string of such resource bundle.
 	 */
 	String bundle() default "";
+
+	/**
+	 * The encoding that will be sued when reading the {@link #bundle()} file.
+	 * The default encoding is ISO-8859-1.
+	 *
+	 * @return  the encoding to use when reading the resource bundle
+	 */
+	String encoding() default "ISO-8859-1";
 	
 	/**
 	 * The default title for this view for modal.

--- a/src/main/java/de/felixroske/jfxsupport/ResourceBundleControl.java
+++ b/src/main/java/de/felixroske/jfxsupport/ResourceBundleControl.java
@@ -1,0 +1,68 @@
+package de.felixroske.jfxsupport;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.net.URL;
+import java.net.URLConnection;
+import java.nio.charset.Charset;
+import java.util.Locale;
+import java.util.PropertyResourceBundle;
+import java.util.ResourceBundle;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Control that uses a custom {@link Charset} when reading resource bundles,
+ * compared to the default charset which is ISO-8859-1.
+ *
+ * @author Emil Forslund
+ * @since  2.1.6
+ */
+public final class ResourceBundleControl extends ResourceBundle.Control {
+
+    private final Charset charset;
+
+    public ResourceBundleControl(Charset charset) {
+        this.charset = requireNonNull(charset);
+    }
+
+    @Override
+    public ResourceBundle newBundle(
+        final String baseName,
+        final Locale locale,
+        final String format,
+        final ClassLoader loader,
+        final boolean reload)
+    throws IllegalAccessException, InstantiationException, IOException {
+
+        final String bundleName = toBundleName(baseName, locale);
+        final String resourceName = toResourceName(bundleName, "properties");
+
+        ResourceBundle bundle = null;
+        InputStream stream    = null;
+        if (reload) {
+            URL url = loader.getResource(resourceName);
+            if (url != null) {
+                URLConnection connection = url.openConnection();
+                if (connection != null) {
+                    connection.setUseCaches(false);
+                    stream = connection.getInputStream();
+                }
+            }
+        } else {
+            stream = loader.getResourceAsStream(resourceName);
+        }
+
+        if (stream != null) {
+            try {
+                bundle = new PropertyResourceBundle(new InputStreamReader(
+                    stream, charset));
+            } finally {
+                stream.close();
+            }
+        }
+
+        return bundle;
+    }
+}


### PR DESCRIPTION
This PR adds the optional parameter `encoding` to the `@FXMLView`-annotation so that the encoding of the resource bundle can be specified. I also bumped up the version of the porject to `2.1.6-SNAPSHOT` since I am not sure what the convention for development versions is in this project.