### PR TITLE
Closes #80: Allow setting custom error action

### DIFF
--- a/src/test/java/de/felixroske/jfxsupport/CustomErrorActionTest.java
+++ b/src/test/java/de/felixroske/jfxsupport/CustomErrorActionTest.java
@@ -1,18 +1,21 @@
 package de.felixroske.jfxsupport;
 
 import de.felixroske.jfxtest.*;
-import org.hamcrest.*;
+import javafx.scene.image.Image;
+import org.hamcrest.CoreMatchers;
 import org.junit.jupiter.api.*;
-import org.testfx.api.*;
+import org.testfx.api.FxToolkit;
 
 import java.util.*;
-import javafx.scene.image.*;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.*;
 
-public class AbstractJavaFxApplicationSupportTest {
+public class CustomErrorActionTest {
 
     private AbstractJavaFxApplicationSupport app;
+
+    ErrorAction errorAction;
 
     @BeforeAll
     public static void beforeClass() {
@@ -26,18 +29,23 @@ public class AbstractJavaFxApplicationSupportTest {
 
     @BeforeEach
     public void setup() throws Exception {
+        errorAction = mock(ErrorAction.class);
         FxToolkit.registerPrimaryStage();
         app = new TestApp();
         app.savedInitialView = SampleView.class;
         app.splashScreen = new SplashScreen();
+        app.setErrorAction(throwable -> errorAction.action());
         FxToolkit.setupApplication(() -> app);
     }
 
     @Test
-    @DisplayName ("Load default icons")
+    @DisplayName ("Custom error action is executed")
     public void loadDefaultIcons() {
-        final Collection<Image> images = new ArrayList<>();
-        images.addAll(app.loadDefaultIcons());
-        assertThat(images.size(), CoreMatchers.is(5));
+        AbstractJavaFxApplicationSupport.showInitialView(SampleIncorrectView.class);
+        verify(errorAction, times(2)).action();
     }
+}
+
+interface ErrorAction {
+    void action();
 }

--- a/src/test/java/de/felixroske/jfxtest/TestApp.java
+++ b/src/test/java/de/felixroske/jfxtest/TestApp.java
@@ -1,0 +1,7 @@
+package de.felixroske.jfxtest;
+
+import de.felixroske.jfxsupport.AbstractJavaFxApplicationSupport;
+
+public class TestApp extends AbstractJavaFxApplicationSupport {
+
+}


### PR DESCRIPTION
A protected setter was added to allow the assignment of a a custom error
action when an unexpected behaviour occurs.