### PR TITLE
Add controller aop support

### DIFF
--- a/src/main/java/de/felixroske/jfxsupport/AbstractFxmlController.java
+++ b/src/main/java/de/felixroske/jfxsupport/AbstractFxmlController.java
@@ -1,0 +1,58 @@
+package de.felixroske.jfxsupport;
+
+import javafx.collections.MapChangeListener;
+import javafx.fxml.FXML;
+import javafx.fxml.FXMLLoader;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+
+public abstract class AbstractFxmlController {
+
+  public AbstractFxmlController() {
+
+  }
+
+  void setFields(FXMLLoader loader) {
+    loader.getNamespace().addListener((MapChangeListener<? super String, ? super Object>) value -> {
+      Field field = getFxmlField(value.getKey());
+      if (field == null) {
+        return;
+      }
+      if (value.wasAdded()) {
+        try {
+          field.set(this, loader.getNamespace().get(value.getKey()));
+        } catch (IllegalAccessException e) {
+          throw new IllegalStateException("Failed to set field for controller");
+        }
+      } else if (value.wasRemoved()) {
+        try {
+          field.set(this, null);
+        } catch (IllegalAccessException e) {
+          throw new IllegalStateException("Failed to set field for controller");
+        }
+      }
+    });
+  }
+
+  private Field getFxmlField(String fieldName) {
+    Field field;
+    try {
+      field = getClass().getDeclaredField(fieldName);
+    } catch (NoSuchFieldException e) {
+      return null;
+    }
+
+    if (Modifier.isPublic(field.getModifiers())) {
+      return field;
+    }
+    if (field.getAnnotation(FXML.class) != null) {
+      field.setAccessible(true);
+      return field;
+    }
+
+    return null;
+
+  }
+
+}

--- a/src/main/java/de/felixroske/jfxsupport/AbstractFxmlView.java
+++ b/src/main/java/de/felixroske/jfxsupport/AbstractFxmlView.java
@@ -153,7 +153,13 @@ public abstract class AbstractFxmlView implements ApplicationContextAware {
 	private FXMLLoader loadSynchronously(final URL resource, final Optional<ResourceBundle> bundle) throws IllegalStateException {
 
 		final FXMLLoader loader = new FXMLLoader(resource, bundle.orElse(null));
-		loader.setControllerFactory(this::createControllerForType);
+		loader.setControllerFactory(type -> {
+			Object controller = this.createControllerForType(type);
+			if (controller instanceof AbstractFxmlController) {
+				((AbstractFxmlController) controller).setFields(loader);
+			}
+			return controller;
+		});
 
 		try {
 			loader.load();


### PR DESCRIPTION
Controller proxy bean can not set filed by FXMLLoader by reflection, adding a way to support it.

Now we can use AOP in the following way.

```java
@FXMLController
public class MyAopController extends AbstractFxmlController {
    
    @FXML
    private TextField textField;

    public TextField textField2;

    @Transactional
    public void doSomething() {
        assert textField != null;
        assert textField2 != null;
    }

}
```